### PR TITLE
Use varints rather than uint32s to delimit messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,14 @@ the compiler as a subprocess and communicate using binary protocol buffers over
 its standard input and output streams.
 
 For streams (like standard input and output) that don't have built-in message
-boundaries, every message must begin with a 4-byte (32-bit) unsigned
-[little-endian][] integer indicating the length in bytes of the remaining
-message. This matches the best practice described in [the protocol buffer
-documentation][].
+boundaries, every message must begin with an unsigned [varint] indicating the
+length in bytes of the remaining message. This matches the best practice
+described in [the protocol buffer documentation][].
 
-[little-endian]: https://en.wikipedia.org/wiki/Endianness#Little
+> Note that a number of protocol buffer libraries have built-in utilities for
+> reading and writing varint-delimited streams.
+
+[varint]: https://developers.google.com/protocol-buffers/docs/encoding#varints
 [the protocol buffer documentation]: https://developers.google.com/protocol-buffers/docs/techniques#streaming
 
 ### RPCs

--- a/README.md
+++ b/README.md
@@ -47,13 +47,16 @@ its standard input and output streams.
 For streams (like standard input and output) that don't have built-in message
 boundaries, every message must begin with an unsigned [varint] indicating the
 length in bytes of the remaining message. This matches the best practice
-described in [the protocol buffer documentation][].
-
-> Note that a number of protocol buffer libraries have built-in utilities for
-> reading and writing varint-delimited streams.
+described in [the protocol buffer documentation][]. Because JavaScript can't
+easily represent integers larger than 2^53 - 1, messages may be no more than
+2^53 - 1 bytes long. Because it's so unlikely that this will come up in
+practice, implementations are not required to verify it.
 
 [varint]: https://developers.google.com/protocol-buffers/docs/encoding#varints
 [the protocol buffer documentation]: https://developers.google.com/protocol-buffers/docs/techniques#streaming
+
+> Note that a number of protocol buffer libraries have built-in utilities for
+> reading and writing varint-delimited streams.
 
 ### RPCs
 


### PR DESCRIPTION
Uint32 limits message sizes to 4.3 gigabytes, which is very large but
not outside the range of possibility for CSS output.

Partially addresses #37