### PR TITLE
Adds formatted field to CompileFailure and LogEvent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## 1.0.0-beta.8
 
-* Added fields to support formatted errors and logs.
+* Added fields to support requesting and sending formatted errors and logs.
+  * `CompileRequest.alert_style.color`
+  * `CompileRequest.alert_style.ascii`
   * `CompileFailure.formatted`
   * `LogEvent.formatted`
-  * `CompileRequest.color`
 
 * Remove `OutputStyle.NESTED` and `OutputStyle.COMPACT`. It's unlikely that any
   host would support those any time soon.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 1.0.0-beta.8
 
-* Added `CompileFailure.formatted` and `LogEvent.formatted` messages.
+* Added fields to support formatted errors and logs.
+  * `CompileFailure.formatted`
+  * `LogEvent.formatted`
+  * `CompileRequest.color`
 
 ## 1.0.0-beta.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 1.0.0-beta.8
 
 * Added fields to support requesting and sending formatted errors and logs.
-  * `CompileRequest.alert_style.color`
-  * `CompileRequest.alert_style.ascii`
+  * `CompileRequest.alert_color`
+  * `CompileRequest.alert_ascii`
   * `CompileFailure.formatted`
   * `LogEvent.formatted`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-beta.8
+
+* Added `CompileFailure.formatted` and `LogEvent.formatted` messages.
+
 ## 1.0.0-beta.7
 
 * Use `4294967295` as the special ID for error messages that aren't caused by a

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## The Embedded Sass Protocol (1.0.0-beta.7)
+## The Embedded Sass Protocol (pending 1.0.0-beta.8)
 
 * [Overview](#overview)
 * [RPCs](#rpcs)

--- a/embedded_sass.proto
+++ b/embedded_sass.proto
@@ -127,10 +127,10 @@ message InboundMessage {
     // Possible ways to to format errors and logs.
     message AlertStyle {
       // Whether to use terminal colors.
-      bool color = 0;
+      bool color = 1;
 
       // Which encoding to use.
-      Charset encoding = 1;
+      Charset encoding = 2;
     }
 
     // How to format errors and logs.

--- a/embedded_sass.proto
+++ b/embedded_sass.proto
@@ -301,6 +301,11 @@ message OutboundMessage {
       // the format of this stack trace is not specified and is likely to be
       // inconsistent between implementations.
       string stack_trace = 3;
+
+      // A formatted string that contains the message, span (if available), and
+      // trace (if available). The format of this string is not specified and is
+      // likely to be inconsistent between implementations.
+      string formatted = 4;
     }
 
     // The success or failure result of the compilation. Mandatory.
@@ -347,6 +352,11 @@ message OutboundMessage {
     // the format of this stack trace is not specified and is likely to be
     // inconsistent between implementations.
     string stack_trace = 5;
+
+    // A formatted string that contains the message, span (if available), and
+    // trace (if available). The format of this string is not specified and is
+    // likely to be inconsistent between implementations.
+    string formatted = 6;
   }
 
   // A request for a custom importer to convert an imported URL to its canonical

--- a/embedded_sass.proto
+++ b/embedded_sass.proto
@@ -125,6 +125,9 @@ message InboundMessage {
     // custom global functions. They must also reject any custom function names
     // that conflict with function names built into the Sass language.
     repeated string global_functions = 7;
+
+    // Whether to use terminal colors in formatted errors and logs.
+    bool color = 8;
   }
 
   // A response indicating the result of canonicalizing an imported URL.
@@ -302,9 +305,9 @@ message OutboundMessage {
       // inconsistent between implementations.
       string stack_trace = 3;
 
-      // A formatted string that contains the message, span (if available), and
-      // trace (if available). The format of this string is not specified and is
-      // likely to be inconsistent between implementations.
+      // A formatted, human-readable string that contains the message, span
+      // (if available), and trace (if available). The format of this string is
+      // not specified and is likely to be inconsistent between implementations.
       string formatted = 4;
     }
 
@@ -353,9 +356,9 @@ message OutboundMessage {
     // inconsistent between implementations.
     string stack_trace = 5;
 
-    // A formatted string that contains the message, span (if available), and
-    // trace (if available). The format of this string is not specified and is
-    // likely to be inconsistent between implementations.
+    // A formatted, human-readable string that contains the message, span (if
+    // available), and trace (if available). The format of this string is not
+    // specified and is likely to be inconsistent between implementations.
     string formatted = 6;
   }
 

--- a/embedded_sass.proto
+++ b/embedded_sass.proto
@@ -118,8 +118,23 @@ message InboundMessage {
     // that conflict with function names built into the Sass language.
     repeated string global_functions = 7;
 
-    // Whether to use terminal colors in formatted errors and logs.
-    bool color = 8;
+    // Possible ways to encode output.
+    enum Charset {
+      UTF_8 = 0;
+      ASCII = 1;
+    }
+
+    // Possible ways to to format errors and logs.
+    message AlertStyle {
+      // Whether to use terminal colors.
+      bool color = 0;
+
+      // Which encoding to use.
+      Charset encoding = 1;
+    }
+
+    // How to format errors and logs.
+    AlertStyle alert_style = 8;
   }
 
   // A response indicating the result of canonicalizing an imported URL.

--- a/embedded_sass.proto
+++ b/embedded_sass.proto
@@ -118,19 +118,13 @@ message InboundMessage {
     // that conflict with function names built into the Sass language.
     repeated string global_functions = 7;
 
-    // Possible ways to encode output.
-    enum Charset {
-      UTF_8 = 0;
-      ASCII = 1;
-    }
-
     // Possible ways to to format errors and logs.
     message AlertStyle {
-      // Whether to use terminal colors.
+      // Whether to use terminal colors in the alert's formatted message.
       bool color = 1;
 
-      // Which encoding to use.
-      Charset encoding = 2;
+      // Whether to encode the alert's formatted message in ASCII.
+      bool ascii = 2;
     }
 
     // How to format errors and logs.

--- a/embedded_sass.proto
+++ b/embedded_sass.proto
@@ -118,17 +118,12 @@ message InboundMessage {
     // that conflict with function names built into the Sass language.
     repeated string global_functions = 7;
 
-    // Possible ways to to format errors and logs.
-    message AlertStyle {
-      // Whether to use terminal colors in the alert's formatted message.
-      bool color = 1;
+    // Whether to use terminal colors in the formatted message of errors and
+    // logs.
+    bool alert_color = 8;
 
-      // Whether to encode the alert's formatted message in ASCII.
-      bool ascii = 2;
-    }
-
-    // How to format errors and logs.
-    AlertStyle alert_style = 8;
+    // Whether to encode the formatted message of errors and logs in ASCII.
+    bool alert_ascii = 9;
   }
 
   // A response indicating the result of canonicalizing an imported URL.


### PR DESCRIPTION
This allows the compiler to provide a nicely formatted string that
contains all parts of the error/log message.