### PR TITLE
Add VersionRequest.id and VersionResponse.id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-beta.10
+
+* Add `VersionRequest.id` and `VersionResponse.id`.
+
 ## 1.0.0-beta.9
 
 * Added `CanonicalizeRequest.fromImport` and `FileImportRequest.fromImport`

--- a/embedded_sass.proto
+++ b/embedded_sass.proto
@@ -15,6 +15,9 @@ message InboundMessage {
   // which features the compiler supports, or to ensure that it's compatible
   // with the same protocol version the compiler supports.
   message VersionRequest {
+    // This version request's id. Mandatory.
+    uint32 id = 1;
+
     // This message's contents are intentionally empty. It just acts as a signal
     // to the compiler to send a VersionResponse. More fields may be added in
     // the future.
@@ -250,6 +253,9 @@ message InboundMessage {
 message OutboundMessage {
   // A response that contains the version of the embedded compiler.
   message VersionResponse {
+    // This version request's id. Mandatory.
+    uint32 id = 5;
+
     // The version of the embedded protocol, in semver format.
     string protocol_version = 1;
 


### PR DESCRIPTION
This wasn't included originally because there's no information in the
VersionRequest that the response would need to be associated with it.
However, the protocol says every request and response need an ID, so
this helps maintain consistency (and future-proofs against adding
fields to VersionRequest).