### PR TITLE
Fix release tagging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
           )"
       - name: Create release
         if: |
-          steps.version-info.VERSION_MODIFIED == 'true' &&
-            !endsWith(steps.version-info.VERSION, '-dev')
+          steps.version-info.outputs.VERSION_MODIFIED == 'true' &&
+            !endsWith(steps.version-info.outputs.VERSION, '-dev')
         run: |
           git config --global user.name 'SassBot'
           git config --global user.email 'sass.bot.beep.boop@gmail.com'


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idoutputs

The syntax is `jobs.my_job.outputs.job_output1`, and the current code missed the `.outputs.` part.