### PR TITLE
Fix release tagging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           echo "::set-output name=VERSION::$(cat VERSION)"
           echo "::set-output name=VERSION_MODIFIED::$(
-            git diff --quiet HEAD^ VERSION && echo true || echo false
+            git diff --quiet HEAD^ VERSION && echo false || echo true
           )"
       - name: Create release
         if: |


### PR DESCRIPTION
https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---quiet

> Disable all output of the program. Implies `--exit-code`.

https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---exit-code

> Make the program exit with codes similar to diff(1). That is, it exits with 1 if there were differences and 0 means no differences.

The current logic will try to tag where there is no change to `VERSION`. The logic need to be reversed.