### PR TITLE
Improve generated Java code

### DIFF
--- a/embedded_sass.proto
+++ b/embedded_sass.proto
@@ -6,6 +6,9 @@ syntax = "proto3";
 
 package sass.embedded_protocol;
 
+option java_package = "com.sass_lang.embedded_protocol";
+option java_multiple_files = true;
+
 // The wrapper type for all messages sent from the host to the compiler. This
 // provides a `oneof` that makes it possible to determine the type of each
 // inbound message.


### PR DESCRIPTION
These options should improve the java code generated by `protoc`.

The package name follows this convention: https://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html

From a java point-of-view, this would technically be a breaking change which should therefore be targeted for a new major version (2.0.0). For all other languages, this change should be transparent.